### PR TITLE
Load projectile known projects when needed

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -1462,7 +1462,7 @@ for the first action, etc) of the action to set as default."
   (ivy-read (projectile-prepend-project-name "Switch to project: ")
             (if counsel-projectile-remove-current-project
                 (projectile-relevant-known-projects)
-              projectile-known-projects)
+              (projectile-known-projects))
             :preselect (and (projectile-project-p)
                             (abbreviate-file-name (projectile-project-root)))
             :action (or (and default-action


### PR DESCRIPTION
Projectile no longer loads known projects on load. This causes `projectile-known-projects` to be empty. Substituting it for the function makes projectile load known projects when needed.

Fixes #188.